### PR TITLE
添加crack依赖

### DIFF
--- a/mos-sdk.gemspec
+++ b/mos-sdk.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "crack", "~> 0.4"
+
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
mos-sdk.gemspec缺少对crack的依赖，下载下来的sdk，无法正常使用
